### PR TITLE
feat: 카카오 API 이용한 주소 검색

### DIFF
--- a/src/main/java/com/zerobase/whataday/config/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/whataday/config/SecurityConfiguration.java
@@ -1,0 +1,17 @@
+package com.zerobase.whataday.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http.authorizeRequests()
+        .anyRequest().permitAll();
+  }
+}

--- a/src/main/java/com/zerobase/whataday/controller/KakaoApiController.java
+++ b/src/main/java/com/zerobase/whataday/controller/KakaoApiController.java
@@ -1,40 +1,23 @@
 package com.zerobase.whataday.controller;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
+
+import com.zerobase.whataday.service.ApiService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 @RestController
+@RequiredArgsConstructor
 public class KakaoApiController {
+  private final ApiService apiService;
 
   /**
    * 사용자가 검색한 address 값을 가지고 카카오 location API 사용하여 검색한 주소값, 위도, 경도를 return
    */
   @GetMapping("/search/{address}")
-  public ResponseEntity<?> searchAddress(@PathVariable("address") String address) throws Exception {
-    String apiKey = "KakaoAK " + "dcaa9a59bbcfc8f49ef3f4fc53648c4e";
-    String url = "https://dapi.kakao.com/v2/local/search/address.json?query=" + address;
-    RestTemplate restTemplate = new RestTemplate();
-
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
-    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
-    headers.set("Authorization", apiKey);
-
-    HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(headers);
-    ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.GET, httpEntity,
-        String.class);
-
-    return responseEntity;
+  public ResponseEntity<String> searchAddress(@PathVariable("address") String address) {
+      return apiService.searchAddress(address);
   }
 }

--- a/src/main/java/com/zerobase/whataday/controller/KakaoApiController.java
+++ b/src/main/java/com/zerobase/whataday/controller/KakaoApiController.java
@@ -1,0 +1,40 @@
+package com.zerobase.whataday.controller;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+public class KakaoApiController {
+
+  /**
+   * 사용자가 검색한 address 값을 가지고 카카오 location API 사용하여 검색한 주소값, 위도, 경도를 return
+   */
+  @GetMapping("/search/{address}")
+  public ResponseEntity<?> searchAddress(@PathVariable("address") String address) throws Exception {
+    String apiKey = "KakaoAK " + "dcaa9a59bbcfc8f49ef3f4fc53648c4e";
+    String url = "https://dapi.kakao.com/v2/local/search/address.json?query=" + address;
+    RestTemplate restTemplate = new RestTemplate();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    headers.set("Authorization", apiKey);
+
+    HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(headers);
+    ResponseEntity<String> responseEntity = restTemplate.exchange(url, HttpMethod.GET, httpEntity,
+        String.class);
+
+    return responseEntity;
+  }
+}

--- a/src/main/java/com/zerobase/whataday/controller/ScheduleController.java
+++ b/src/main/java/com/zerobase/whataday/controller/ScheduleController.java
@@ -1,0 +1,57 @@
+package com.zerobase.whataday.controller;
+
+import com.zerobase.whataday.domain.ScheduleForm;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@RestController
+@RequestMapping("/schedule")
+public class ScheduleController {
+
+  @GetMapping("/add")
+  public Map<String, String> addSchedule(ScheduleForm schedule){
+    Map<String, String> map = new HashMap<>();
+
+    return map;
+  }
+
+  /**
+   * 사용자가 검색한 address 값을 가지고
+   * 카카오 location API 사용하여
+   * 검색한 주소값, 위도, 경도를 return
+   */
+  @GetMapping("/search/address")
+  public String searchAddress() throws URISyntaxException {
+    String apiKey = "";
+    String address = "서울시청";
+    String url = "https://dapi.kakao.com/v2/local/search/address.JSON?query=" + address;
+    String apiResult = "";
+
+    try {
+      URI uri = new URI(String.format(url, apiKey));
+      RestTemplate restTemplate = new RestTemplate();
+      HttpHeaders headers = new HttpHeaders();
+      headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+      apiResult = restTemplate.getForObject(uri, String.class);
+
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return apiResult;
+  }
+
+
+}

--- a/src/main/java/com/zerobase/whataday/controller/ScheduleController.java
+++ b/src/main/java/com/zerobase/whataday/controller/ScheduleController.java
@@ -1,18 +1,11 @@
 package com.zerobase.whataday.controller;
 
 import com.zerobase.whataday.domain.ScheduleForm;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 @RestController
 @RequestMapping("/schedule")
@@ -24,34 +17,5 @@ public class ScheduleController {
 
     return map;
   }
-
-  /**
-   * 사용자가 검색한 address 값을 가지고
-   * 카카오 location API 사용하여
-   * 검색한 주소값, 위도, 경도를 return
-   */
-  @GetMapping("/search/address")
-  public String searchAddress() throws URISyntaxException {
-    String apiKey = "";
-    String address = "서울시청";
-    String url = "https://dapi.kakao.com/v2/local/search/address.JSON?query=" + address;
-    String apiResult = "";
-
-    try {
-      URI uri = new URI(String.format(url, apiKey));
-      RestTemplate restTemplate = new RestTemplate();
-      HttpHeaders headers = new HttpHeaders();
-      headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-
-      apiResult = restTemplate.getForObject(uri, String.class);
-
-
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-
-    return apiResult;
-  }
-
 
 }

--- a/src/main/java/com/zerobase/whataday/domain/ScheduleForm.java
+++ b/src/main/java/com/zerobase/whataday/domain/ScheduleForm.java
@@ -1,0 +1,12 @@
+package com.zerobase.whataday.domain;
+
+import lombok.Getter;
+
+@Getter
+public class ScheduleForm {
+  private Long userId;
+  private String title;
+  private String description;
+  private String address;
+  private String datetime;
+}

--- a/src/main/java/com/zerobase/whataday/domain/SignUpForm.java
+++ b/src/main/java/com/zerobase/whataday/domain/SignUpForm.java
@@ -1,10 +1,8 @@
 package com.zerobase.whataday.domain;
 
 import lombok.Data;
-import lombok.ToString;
 
 @Data
-@ToString
 public class SignUpForm {
   private Long Id;
   private String name;

--- a/src/main/java/com/zerobase/whataday/service/ApiService.java
+++ b/src/main/java/com/zerobase/whataday/service/ApiService.java
@@ -1,0 +1,9 @@
+package com.zerobase.whataday.service;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ApiService {
+  ResponseEntity<String> searchAddress(String address);
+}

--- a/src/main/java/com/zerobase/whataday/service/Impl/ApiServiceImpl.java
+++ b/src/main/java/com/zerobase/whataday/service/Impl/ApiServiceImpl.java
@@ -1,0 +1,33 @@
+package com.zerobase.whataday.service.Impl;
+
+import com.zerobase.whataday.service.ApiService;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class ApiServiceImpl implements ApiService {
+
+  @Override
+  public ResponseEntity<String> searchAddress(String address) {
+    String apiKey = "KakaoAK " + "key";
+    String url = "https://dapi.kakao.com/v2/local/search/address.json?query=" + address;
+    RestTemplate restTemplate = new RestTemplate();
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+    headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+    headers.set("Authorization", apiKey);
+
+    HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(headers);
+
+    return restTemplate.exchange(url, HttpMethod.GET, httpEntity, String.class);
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
사용자가 입력한 주소값을 검색해서 위도, 경도를 반환하는 API를 사용했습니다.
사용한 API는 카카오 local API 입니다 - [https://developers.kakao.com/docs/latest/ko/local/dev-guide](url)
KakaoApiController에서 "/search/{address}"로 사용자로부터 address값을 입력받고 ResponseEntity<String>을 반환합니다. 
**TO-BE**
반환받은 ResponseEntity<String>의 값 중에서 위도, 경도, 그리고 주소값을 ScheduleForm에 집어넣어서 Schedule에 저장하는 서비스를 작성하려고 합니다.

ResponseEntity를 받아 오는 것은 좋은데, 받아온 값을 사용하려면 프론트엔드에서 ResponseEntity 내부의 값을 정제한 다음 ScheduleForm에 해당하는 값들(userId, address, longitude 등)로 받아온 것으로 가정하고 사용해야 하는 것이 맞나요?